### PR TITLE
Add controller test helper for asserting submissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ require 'test_helper'
 require 'microform/test_methods'
 
 class Admin::ProjectsControllerTest < ActionDispatch::IntegrationTest
+  include Microform::TestMethods
+
   test "should create post" do
     post = posts(:one)
     valid_double = OpenStruct.new(post: post)

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Other tests could cover submitting certain attributes and ensuring that the reco
 
 Using the form object pattern allows you to extract tests that cover updating records from your controller/integration tests. This keeps the tests that cover your controllers and routing focussed on those concerns specifically. If code is introduced that breaks form submission, only the form object tests will fail, making your application easier to debug.
 
-Microform provides a `Microform::TestMethods` module for asserting and stubbing form submissions.
+Microform provides a `Microform::TestMethods` module for asserting and stubbing form submissions with Minitest.
 
 ```ruby
 require 'test_helper'

--- a/README.md
+++ b/README.md
@@ -127,14 +127,14 @@ Other tests could cover submitting certain attributes and ensuring that the reco
 
 Using the form object pattern allows you to extract tests that cover updating records from your controller/integration tests. This keeps the tests that cover your controllers and routing focussed on those concerns specifically. If code is introduced that breaks form submission, only the form object tests will fail, making your application easier to debug.
 
-Microform provides a `Microform::TestMethods` module for asserting and stubbing form submissions with Minitest.
+Microform provides a `Microform::Test::IntegrationMethods` module for asserting and stubbing form submissions with Minitest.
 
 ```ruby
 require 'test_helper'
 require 'microform/test_methods'
 
 class Admin::ProjectsControllerTest < ActionDispatch::IntegrationTest
-  include Microform::TestMethods
+  include Microform::Test::IntegrationMethods
 
   test "should create post" do
     post = posts(:one)

--- a/lib/microform/test_methods.rb
+++ b/lib/microform/test_methods.rb
@@ -2,30 +2,32 @@ require "minitest/stub_any_instance"
 require "minitest/mock"
 
 module Microform
-  module TestMethods
-    def assert_submits form_kind, stub: nil, &block
-      controller = self.class.name.gsub(/Test\z/, "").constantize
-      form = form_kind.new OpenStruct.new(foo: :bar)
+  module Test
+    module IntegrationMethods
+      def assert_submits form_kind, stub: nil, &block
+        controller = self.class.name.gsub(/Test\z/, "").constantize
+        form = form_kind.new OpenStruct.new(foo: :bar)
 
-      # Mangle the variable names to circumvent any issues with method
-      # collisions when the `submit` lambda is instance eval'ed within
-      # the controller.
-      __microform_form_kind = form_kind
-      __microform_test = self
-      __microform_stub = stub
+        # Mangle the variable names to circumvent any issues with method
+        # collisions when the `submit` lambda is instance eval'ed within
+        # the controller.
+        __microform_form_kind = form_kind
+        __microform_test = self
+        __microform_stub = stub
 
-      submit = -> f, *args {
-        __microform_test.assert_equal __microform_form_kind, f
+        submit = -> f, *args {
+          __microform_test.assert_equal __microform_form_kind, f
 
-        if __microform_stub
-          __microform_stub
-        else
-          __minitest_any_instance_stub__submit f, *args
+          if __microform_stub
+            __microform_stub
+          else
+            __minitest_any_instance_stub__submit f, *args
+          end
+        }
+
+        controller.stub_any_instance :submit, submit do
+          yield form
         end
-      }
-
-      controller.stub_any_instance :submit, submit do
-        yield form
       end
     end
 
@@ -37,6 +39,5 @@ module Microform
         true
       end
     end
-
   end
 end

--- a/lib/microform/test_methods.rb
+++ b/lib/microform/test_methods.rb
@@ -1,0 +1,39 @@
+require "minitest/stub_any_instance"
+require "minitest/mock"
+
+module Microform
+  module TestMethods
+    def assert_submits form_kind, stub: nil, &block
+      controller = self.class.name.gsub(/Test\z/, "").constantize
+      form = form_kind.new OpenStruct.new(foo: :bar)
+
+      __microform_form_kind = form_kind
+      __microform_test = self
+      __microform_stub = stub
+
+      submit = -> f, *args {
+        __microform_test.assert_equal __microform_form_kind, f
+
+        if __microform_stub
+          __microform_stub
+        else
+          __minitest_any_instance_stub__submit f, *args
+        end
+      }
+
+      controller.stub_any_instance :submit, submit do
+        yield form
+      end
+    end
+
+    class ValidForm
+      def initialize(*)
+      end
+
+      def valid?
+        true
+      end
+    end
+
+  end
+end

--- a/lib/microform/test_methods.rb
+++ b/lib/microform/test_methods.rb
@@ -7,6 +7,9 @@ module Microform
       controller = self.class.name.gsub(/Test\z/, "").constantize
       form = form_kind.new OpenStruct.new(foo: :bar)
 
+      # Mangle the variable names to circumvent any issues with method
+      # collisions when the `submit` lambda is instance eval'ed within
+      # the controller.
       __microform_form_kind = form_kind
       __microform_test = self
       __microform_stub = stub

--- a/microform.gemspec
+++ b/microform.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rails", ">= 5.0"
+  spec.add_dependency "minitest-stub_any_instance"
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"

--- a/test/test_methods_test.rb
+++ b/test/test_methods_test.rb
@@ -30,7 +30,7 @@ class TestMethodsTest < Minitest::Test
   end
 
   class FooControllerTest < Minitest::Test
-    include Microform::TestMethods
+    include Microform::Test::IntegrationMethods
   end
 
   class FooController

--- a/test/test_methods_test.rb
+++ b/test/test_methods_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+require "microform/test_methods"
+
+class TestMethodsTest < Minitest::Test
+  def test_asserts_controller_submits_correct_form
+    runner = FooControllerTest.new :foo
+    assert_raises MiniTest::Assertion do
+      runner.assert_submits FooForm do
+        FooController.new.submit BarForm, Foo.new("hi"), {}
+      end
+    end
+  end
+
+  def test_returns_original_form_from_submission
+    runner = FooControllerTest.new :foo
+    runner.assert_submits FooForm do
+      form = FooController.new.submit FooForm, Foo.new("hi"), {}
+      assert_kind_of FooForm, form
+    end
+  end
+
+  def test_returns_stubbed_value
+    runner = FooControllerTest.new :foo
+    stub = FormStub.new
+
+    runner.assert_submits FooForm, stub: stub do
+      form = FooController.new.submit FooForm, Foo.new("hi"), {}
+      assert_equal stub, form
+    end
+  end
+
+  class FooControllerTest < Minitest::Test
+    include Microform::TestMethods
+  end
+
+  class FooController
+    def submit form_kind, record, params
+      form_kind.new record
+    end
+  end
+
+  class FooForm
+    def initialize record
+    end
+
+    def submit form_kind, record, *args
+      form_kind.new record
+    end
+  end
+
+  class BarForm
+    def initialize record
+    end
+
+    def submit *args
+    end
+  end
+
+  class FormStub
+  end
+
+  Foo = Struct.new(:title)
+end


### PR DESCRIPTION
This pull request addresses both #12 and #9. I've introduced a `Microform::TestMethods` module that can be included in a Minitest test suite. The added `assert_submits` method follows the syntax as discussed last in #9.

Questions:
— Does the README language sufficiently describe both how and why tests can be written?
— Should the name `Microform::TestMethods` mention that it is for controller/integration tests? I was thinking specifically about `Rack::Test::Methods`, though in that context the methods are more clearly meant for testing Rack apps. What happens if we want to introduce a test methods for form tests?