### PR TITLE
Add check that a form was submitted at all to assert_submits

### DIFF
--- a/lib/microform/test_methods.rb
+++ b/lib/microform/test_methods.rb
@@ -14,8 +14,10 @@ module Microform
         __microform_form_kind = form_kind
         __microform_test = self
         __microform_stub = stub
+        __microform_submitted = false
 
         submit = -> f, *args {
+          __microform_submitted = true
           __microform_test.assert_equal __microform_form_kind, f
 
           if __microform_stub
@@ -28,6 +30,9 @@ module Microform
         controller.stub_any_instance :submit, submit do
           yield form
         end
+
+        assert __microform_submitted,
+               "Expected #{controller} to submit a #{form_kind}"
       end
     end
 

--- a/test/test_methods_test.rb
+++ b/test/test_methods_test.rb
@@ -11,6 +11,19 @@ class TestMethodsTest < Minitest::Test
     end
   end
 
+  def test_asserts_controller_submits_at_all
+    runner = FooControllerTest.new :foo
+
+    error = assert_raises MiniTest::Assertion do
+      runner.assert_submits FooForm do
+      end
+    end
+
+    assert_equal <<~EXPECTED.chomp, error.message
+      Expected TestMethodsTest::FooController to submit a TestMethodsTest::FooForm
+    EXPECTED
+  end
+
   def test_returns_original_form_from_submission
     runner = FooControllerTest.new :foo
     runner.assert_submits FooForm do


### PR DESCRIPTION
I realized that the `assert_submits` test helper doesn't fail if no form is submitted at all.
This potentially opens up a false positive where the call to `submit` is removed from the controller
action, or the call is circumvented by an erroneous conditional branch, which should break a test
that asserts that a certain form is actually submitted.